### PR TITLE
 Enhancement for sendTriState

### DIFF
--- a/src/RCSwitchNode.cpp
+++ b/src/RCSwitchNode.cpp
@@ -24,6 +24,7 @@ void RCSwitchNode::Init(v8::Local<v8::Object> exports) {
   Nan::SetPrototypeMethod(tpl, "disableTransmit", DisableTransmit);
   Nan::SetPrototypeMethod(tpl, "switchOn", SwitchOn);
   Nan::SetPrototypeMethod(tpl, "switchOff", SwitchOff);
+  Nan::SetPrototypeMethod(tpl, "sendTriState", SendTriState);
 
   constructor.Reset(tpl->GetFunction());
   exports->Set(Nan::New("RCSwitch").ToLocalChecked(), tpl->GetFunction());
@@ -91,6 +92,16 @@ void RCSwitchNode::Send(const Nan::FunctionCallbackInfo<v8::Value>& info) {
   Nan::Utf8String v8str(info[0]);
   obj->rcswitch.send(*v8str);
 
+  info.GetReturnValue().Set(true);
+}
+
+void RCSwitchNode::SendTriState(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  Nan::HandleScope scope;
+
+  RCSwitchNode* obj = ObjectWrap::Unwrap<RCSwitchNode>(info.Holder());
+
+  Nan::Utf8String v8str(info[0]);
+  obj->rcswitch.sendTriState(*v8str);
   info.GetReturnValue().Set(true);
 }
 

--- a/src/RCSwitchNode.h
+++ b/src/RCSwitchNode.h
@@ -20,6 +20,7 @@ class RCSwitchNode : public Nan::ObjectWrap {
   #define switchOp3(p1, p2, p3) { if(switchOn) thiz->rcswitch.switchOn((p1), (p2), (p3)); else thiz->rcswitch.switchOff((p1), (p2), (p3)); }
   static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
   static void Send(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static void SendTriState(const Nan::FunctionCallbackInfo<v8::Value>& info);
   static void EnableTransmit(const Nan::FunctionCallbackInfo<v8::Value>& info);
   static void DisableTransmit(const Nan::FunctionCallbackInfo<v8::Value>& info);
   static void SwitchOn(const Nan::FunctionCallbackInfo<v8::Value>& info);


### PR DESCRIPTION
Some remote sockets are not compatible with the normal on and of functions but are supported by the sendTriState function of the original library. (like miro electric http://blog.johjoh.de/funksteckdosen-umrechnung-fur-culcuxd/).

I added the methods to provide the setTriState function on the node.js interface. 
